### PR TITLE
Don't use utf8.DecodeRune

### DIFF
--- a/go-wc.go
+++ b/go-wc.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sync"
 	"unicode"
-	"unicode/utf8"
 )
 
 const version = "0.0.1"
@@ -43,13 +42,13 @@ func (c *Counter) Count(r io.Reader) (bool, error) {
 			bytesRead := p[:n]
 			inField := false
 			for i := 0; i < len(bytesRead); {
-				r, size := utf8.DecodeRune(bytesRead[i:])
+				b, size := bytesRead[i : i+1][0], 1
 				wasInField := inField
-				inField = !unicode.IsSpace(r)
+				inField = !unicode.IsSpace(rune(b))
 				if inField && !wasInField {
 					localCounter.words += 1
 				}
-				if r == '\n' {
+				if rune(b) == '\n' {
 					localCounter.lines += 1
 				}
 				i += size


### PR DESCRIPTION
Try count by a byte because the bottleneck is `utf8.DecodeRune`.

This implementation can't count multibyte `characters` correctly but the spped is faster than `wc` especially in big files.

Here is a benchmark.

small file (3.4KB):

```
➜  bench-go-wc  time ./bench.sh wc vimrc 1000
./bench.sh wc vimrc 1000  0.75s user 1.00s system 76% cpu 2.278 total
➜  bench-go-wc  time ./bench.sh go-wc vimrc 1000
./bench.sh go-wc vimrc 1000  0.70s user 2.32s system 65% cpu 4.589 total
```

big file (416MB):

```
➜  bench-go-wc  time ./bench.sh wc dump.sql 10
./bench.sh wc dump.sql 10  17.09s user 0.72s system 99% cpu 17.919 total
➜  bench-go-wc  time ./bench.sh go-wc dump.sql 10
./bench.sh go-wc dump.sql 10  45.10s user 1.83s system 355% cpu 13.192 total
```

ref: http://takatoshiono.hatenablog.com/entry/2016/09/22/024605
